### PR TITLE
fix: Update PluginWebpackConfig to new API

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,6 @@ const PluginWebpackConfig = require('graylog-web-plugin').PluginWebpackConfig;
 const loadBuildConfig = require('graylog-web-plugin').loadBuildConfig;
 const path = require('path');
 
-module.exports = new PluginWebpackConfig('org.graylog.plugins.sample.SamplePlugin', loadBuildConfig(path.resolve(__dirname, './build.config')), {
+module.exports = new PluginWebpackConfig(path.resolve(__dirname), 'org.graylog.plugins.sample.SamplePlugin', loadBuildConfig(path.resolve(__dirname, './build.config')), {
   // Here goes your additional webpack configuration.
 });


### PR DESCRIPTION
## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

I don't know where exactly but the API changed and I needed this to fix a project.